### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,18 +1,49 @@
 # Contributor Covenant Code of Conduct
 
+## Our Purpose
+
+With this project, we hope to help researchers improve their coding
+skills. One way we do so is by modeling coding community standards of
+practice and reproducible workflows. Another way is by welcoming
+researchers who are not part of the core team of contributors to
+participate.
+
+If you write code for research (or are learning to do so), you are a
+coder. That said, we acknowledge that coding communities, like many
+communities, have norms that can sometimes feel cryptic and unfriendly
+to newcomers. In situations where deviations from these norms --- such
+as posing a question in an online forum without following a standard
+protocol --- are met with ridicule and snark, newcomers are made to
+feel unwelcome. Unfortunately, some newcomers to coding communities
+have also been made to feel unwelcome based on aspects of their
+identity.
+
+We believe that ridicule, snark, and identity-based exclusion work
+against our purpose of improving coding practices and building
+community. Accordingly, we will not replicate those practices here and
+instead offer a positive pledge of what we will do to foster a
+supportive community.
+
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
-size, disability, ethnicity, sex characteristics, gender identity and expression,
-level of experience, education, socio-economic status, nationality, personal
-appearance, race, religion, or sexual identity and orientation.
+contributors and maintainers pledge to making participation in our
+project and our community a harassment-free experience for everyone,
+regardless of age, body size, disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+In addition, we pledge that questions by community members and
+deviations from standards of practice will never be met with
+hostility. Rather, we as contributors and maintainers will strive to
+be kind and do our best to point community members to helpful
+resources.
 
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+Examples of behavior that contributes to creating a positive
+environment include:
 
 * Using welcoming and inclusive language
 * Being respectful of differing viewpoints and experiences
@@ -22,60 +53,66 @@ include:
 
 Examples of unacceptable behavior by participants include:
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
+* The use of sexualized language or imagery and unwelcome sexual
+ attention or advances
+* Trolling, insulting/derogatory comments, and personal or political
+  attacks
 * Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+* Publishing others' private information, such as a physical or
+ electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in
+ a professional setting
 
 ## Our Responsibilities
 
-Project maintainers are responsible for clarifying the standards of acceptable
-behavior and are expected to take appropriate and fair corrective action in
-response to any instances of unacceptable behavior.
+Project maintainers are responsible for clarifying the standards of
+acceptable behavior and are expected to take appropriate and fair
+corrective action in response to any instances of unacceptable
+behavior.
 
-Project maintainers have the right and responsibility to remove, edit, or
-reject comments, commits, code, wiki edits, issues, and other contributions
-that are not aligned to this Code of Conduct, or to ban temporarily or
-permanently any contributor for other behaviors that they deem inappropriate,
-threatening, offensive, or harmful.
+Project maintainers have the right and responsibility to remove, edit,
+or reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct, or to ban
+temporarily or permanently any contributor for other behaviors that
+they deem inappropriate, threatening, offensive, or harmful.
 
 ## Scope
 
-This Code of Conduct applies both within project spaces and in public spaces
-when an individual is representing the project or its community. Examples of
-representing a project or community include using an official project e-mail
-address, posting via an official social media account, or acting as an appointed
-representative at an online or offline event. Representation of a project may be
-further defined and clarified by project maintainers.
+This Code of Conduct applies both within project spaces and in public
+spaces when an individual is representing the project or its
+community. Examples of representing a project or community include
+using an official project e-mail address, posting via an official
+social media account, or acting as an appointed representative at an
+online or offline event. Representation of a project may be further
+defined and clarified by project maintainers.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting any member of the core project team: 
+Instances of abusive, harassing, or otherwise unacceptable behavior
+may be reported by contacting Benjamin Skinner directly at
+btskinner@coe.ufl.edu or any other member of the core project team:
 
-- Will Doyle
-- Ozan Jaquette
-- Patricia Martin
-- Karina Salazar
-- Benjamin Skinner: btskinner@coe.ufl.edu
+- [Will Doyle](https://peabody.vanderbilt.edu/bio/william-doyle), 
+- [Ozan Jaquette](https://emraresearch.org/), 
+- [Patricia Martin](https://emraresearch.org/),
+- [Karina Salazar](https://www.coe.arizona.edu/karina-g-salazar)
+- [Benjamin Skinner](https://btskinner.io)
 
-All complaints will be reviewed and investigated and will result in a response that
-is deemed necessary and appropriate to the circumstances. The project team is
-obligated to maintain confidentiality with regard to the reporter of an incident.
-Further details of specific enforcement policies may be posted separately.
+All complaints will be reviewed and investigated and will result in a
+response that is deemed necessary and appropriate to the
+circumstances. The project team is obligated to maintain
+confidentiality with regard to the reporter of an incident. Further
+details of specific enforcement policies may be posted separately.
 
-Project maintainers who do not follow or enforce the Code of Conduct in good
-faith may face temporary or permanent repercussions as determined by other
-members of the project's leadership.
+Project maintainers who do not follow or enforce the Code of Conduct
+in good faith may face temporary or permanent repercussions as
+determined by other members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+This Code of Conduct is adapted from the [Contributor
+Covenant][homepage], version 1.4, available at
+https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
 [homepage]: https://www.contributor-covenant.org
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,83 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, sex characteristics, gender identity and expression,
+level of experience, education, socio-economic status, nationality, personal
+appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+ advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+ address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+ professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting any member of the core project team: 
+
+- Will Doyle
+- Ozan Jaquette
+- Patricia Martin
+- Karina Salazar
+- Benjamin Skinner: btskinner@coe.ufl.edu
+
+All complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see
+https://www.contributor-covenant.org/faq


### PR DESCRIPTION
Per our conversations about wanting other researchers to feel comfortable contributing, I initialized a code of conduct using a standard template. While I do not expect to have any issues, I think a code of conduct is a good thing to have for any project that invites external contributions.

I listed everyone as a potential contact for enforcement of code violations (lines 60-64), but gave only gave my email. We can keep it with just me, have all core members, or something in between.

To facilitate this process, if everyone could just respond with their personal preference, I can adjust the list accordingly. I see these as the options:

1. Only Ben is a contact (not important that it's me, per se, but just have one person)
2. You **DO NOT** want to be a contact (and we'll remove your name from the list)
3. You **DO** want to be a contact and have your email listed